### PR TITLE
Move Build File

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@
 .vscode/
 
 # CMake
+build/
 CMakeLists.txt.user
 CMakeCache.txt
 CMakeFiles

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,4 +4,4 @@ project(DA_Project)
 
 set(CMAKE_CXX_STANDARD 17)
 
-add_executable(da_project main.cpp data_structs/graph.cpp)
+add_executable(da_project src/main.cpp src/data_structs/graph.cpp)


### PR DESCRIPTION
When building the project it cluttered the `src` folder.
Build file `CMakeLists.txt` was moved out of the src folder.

### How to Build

To build the project use VSCode, when you open the project it asks you to select the CMakeLists file and to select the desired compiler.
Then you can use the build button and the run button to execute the code.

If you wanna do it manually, to build run:

```
cmake --build ./build --target all --
```

To run the compiled program run:

```
./build/da_project
```